### PR TITLE
Downgrade pnpm version requirement in package.json

### DIFF
--- a/infra/package.json
+++ b/infra/package.json
@@ -6,7 +6,7 @@
   },
   "engines": {
     "node": ">22.0.0 <25.0.0",
-    "pnpm": ">=10.22.0",
+    "pnpm": ">=10.16.0",
     "npm": "\n\nUse pnpm!!\n\n"
   },
   "scripts": {


### PR DESCRIPTION
Dependabot uses older version of pnpm what we had specified in `package.json`.